### PR TITLE
Adds Dockerized eb client

### DIFF
--- a/Dockerfile.eb
+++ b/Dockerfile.eb
@@ -1,0 +1,4 @@
+FROM python:3-alpine
+
+RUN pip install awsebcli
+ENTRYPOINT [ "eb" ]

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@ Welcome to the beanstalk module for conjur.
 
 in this repo we  hope to provide a quick way to drop in and deploy conjur https://www.conjur.org/get-started/install-conjur.html into a beanstalk multi docker container... more to come.
 
-
-
-Steps to get setup:
+### Steps to get setup
 
 1) Get an AWS account and setup the beanstalk client: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3-install.html
 
@@ -22,3 +20,19 @@ Helpful links:
 * https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create_deploy_docker.html
 * https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create_deploy_docker_v2config.html
 * https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create_deploy_docker-eblocal.html
+
+### Using the Amazon EB CLI in Docker
+
+1. Run `bin/build-eb-image`
+
+   This will install Elastic Beanstalk's CLI in a clean Python environment and
+   tag it as `amazon-eb-cli`
+2. To use it:
+   
+   ```sh-session
+   $ docker run --rm -it amazon-eb-cli -h
+   usage: eb (sub-commands ...) [options ...] {arguments ...}
+   
+   Welcome to the Elastic Beanstalk Command Line Interface (EB CLI). 
+   For more information on a specific command, type "eb {cmd} --help".
+   ```

--- a/bin/build-eb-image
+++ b/bin/build-eb-image
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eu
+TAG=amazon-eb-cli
+
+cd "$(git rev-parse --show-toplevel)"
+docker build . -f Dockerfile.eb --tag "$TAG"


### PR DESCRIPTION
#### What does this PR do?

It adds an option to use `eb` in a container, in case you have a noisy and questionable local Python environment like I do.

#### How to test?

1. Switch to this branch
2. Follow instructions in the `README` under "Using the Amazon EB CLI in Docker"